### PR TITLE
feat: add link upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Room Assignment System (Streamlit + Python)
 
-A Streamlit app that assigns guests to rooms/campsites for a tourism business.Users upload two CSVs (families.csv and rooms.csv), then the app assigns rooms under hard and soft constraints, provides filters and diagnostics, supports manual overrides and “what‑if” tests, and exports a Daily Operations Sheet in Hebrew layout.
+A Streamlit app that assigns guests to rooms/campsites for a tourism business. Users can upload or link two CSVs (families.csv and rooms.csv), then the app assigns rooms under hard and soft constraints, provides filters and diagnostics, supports manual overrides and “what‑if” tests, and exports a Daily Operations Sheet in Hebrew layout.
 
 ✨ What’s New (Aug 2025)
 
@@ -53,6 +53,8 @@ streamlit run app.py
 Open the URL shown by Streamlit.
 
 📥 CSV Inputs
+
+You may upload the CSV files directly or provide links to them. Use the toggle in the app's upload section to choose the method.
 
 families.csv (one row = one booking)
 

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -29,13 +29,20 @@ def sort_by_room_natural(df: pd.DataFrame, room_col: str = "room") -> pd.DataFra
     # map each room value -> a sortable key via _room_sort_key
     return df.sort_values(by=room_col, key=lambda s: s.astype(str).map(_room_sort_key))
 
-def read_csv(file):
-    """Read CSV with sane defaults (handle Hebrew headers and avoid 'nan' strings)."""
+def read_csv(src):
+    """Read CSV from an uploaded file or a URL.
+
+    Uses UTF‑8‑SIG decoding and avoids converting empty cells to ``"nan"``.
+    ``src`` may be a file-like object (e.g. ``BytesIO``) or a string/URL.
+    """
     try:
-        return pd.read_csv(file, encoding="utf-8-sig", keep_default_na=False, na_filter=False)
+        return pd.read_csv(src, encoding="utf-8-sig", keep_default_na=False, na_filter=False)
     except Exception:
-        file.seek(0)
-        return pd.read_csv(file, keep_default_na=False, na_filter=False)
+        # If this is a file-like object, reset the pointer and try again with
+        # default encoding (some browsers omit the BOM).
+        if hasattr(src, "seek"):
+            src.seek(0)
+        return pd.read_csv(src, keep_default_na=False, na_filter=False)
 
 # ----------------- DataFrame helpers -----------------
 

--- a/ui/upload.py
+++ b/ui/upload.py
@@ -8,20 +8,67 @@ from logic.validate import validate_constraints
 
 def render_uploads():
     st.markdown("### 📁 Upload Guest & Room Lists")
-    upload_col1, upload_col2 = st.columns(2)
 
-    with upload_col1:
-        fam_file = st.file_uploader("👨‍👩‍👧 Families CSV", type="csv", label_visibility="collapsed")
-        st.markdown("*👨‍👩‍👧 Families*", help="Upload your families.csv (supports Hebrew headers).")
+    use_links = st.toggle(
+        "Use links instead of file upload",
+        key="use_links",
+        help="Switch to provide URLs pointing to the CSV files.",
+    )
 
-    with upload_col2:
-        room_file = st.file_uploader("🏠 Rooms CSV", type="csv", label_visibility="collapsed")
-        st.markdown("*🏠 Rooms*", help="Upload your rooms.csv (room numbers may repeat across room types).")
+    # Clear previous data when switching modes
+    if st.session_state.get("_last_use_links") != use_links:
+        st.session_state["families"] = pd.DataFrame()
+        st.session_state["rooms"] = pd.DataFrame()
+        st.session_state["_last_use_links"] = use_links
 
-    if fam_file:
-        st.session_state["families"] = read_csv(fam_file)
-    if room_file:
-        st.session_state["rooms"] = read_csv(room_file)
+    if use_links:
+        link_col1, link_col2 = st.columns(2)
+
+        with link_col1:
+            fam_url = st.text_input(
+                "👨‍👩‍👧 Families CSV URL",
+                key="fam_url",
+                placeholder="https://example.com/families.csv",
+            )
+
+        with link_col2:
+            room_url = st.text_input(
+                "🏠 Rooms CSV URL",
+                key="room_url",
+                placeholder="https://example.com/rooms.csv",
+            )
+
+        if fam_url:
+            try:
+                st.session_state["families"] = read_csv(fam_url)
+            except Exception as e:
+                st.error(f"Failed to load families CSV: {e}")
+        if room_url:
+            try:
+                st.session_state["rooms"] = read_csv(room_url)
+            except Exception as e:
+                st.error(f"Failed to load rooms CSV: {e}")
+    else:
+        upload_col1, upload_col2 = st.columns(2)
+
+        with upload_col1:
+            fam_file = st.file_uploader("👨‍👩‍👧 Families CSV", type="csv", label_visibility="collapsed")
+            st.markdown(
+                "*👨‍👩‍👧 Families*",
+                help="Upload your families.csv (supports Hebrew headers).",
+            )
+
+        with upload_col2:
+            room_file = st.file_uploader("🏠 Rooms CSV", type="csv", label_visibility="collapsed")
+            st.markdown(
+                "*🏠 Rooms*",
+                help="Upload your rooms.csv (room numbers may repeat across room types).",
+            )
+
+        if fam_file:
+            st.session_state["families"] = read_csv(fam_file)
+        if room_file:
+            st.session_state["rooms"] = read_csv(room_file)
 
     # Auto run after both are present and no prior assignment
     if (


### PR DESCRIPTION
## Summary
- allow guest & room CSVs to be loaded from URLs or uploaded files with a toggle
- extend CSV reader to handle URLs in addition to uploaded files
- document link-based upload option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ecf9e7508832888f6331982e2f29d